### PR TITLE
Fix skein256.cl for macOS

### DIFF
--- a/kernel/skein256.cl
+++ b/kernel/skein256.cl
@@ -46,16 +46,17 @@ __constant static const sph_u64 SKEIN_IV512_256[8] = {
 
 
 
-__constant static const int ROT256[8][4] =
-{
-	46, 36, 19, 37,
-	33, 27, 14, 42,
-	17, 49, 36, 39,
-	44, 9, 54, 56,
-	39, 30, 34, 24,
-	13, 50, 10, 17,
-	25, 29, 39, 43,
-	8, 35, 56, 22,
+__constant static const int ROT256[8][4] = {
+    {
+        46, 36, 19, 37,
+        33, 27, 14, 42,
+        17, 49, 36, 39,
+        44, 9, 54, 56,
+        39, 30, 34, 24,
+        13, 50, 10, 17,
+        25, 29, 39, 43,
+        8, 35, 56, 22,
+    }
 };
 
 __constant static const sph_u64 skein_ks_parity = 0x1BD11BDAA9FC1A22;


### PR DESCRIPTION
Just added parentheses so probably won’t cause problems for other OS,
but if it does can always IFDEF